### PR TITLE
Add insecure option to http check

### DIFF
--- a/check-docs.md
+++ b/check-docs.md
@@ -57,6 +57,7 @@ Example: Make a GET request to a pod and expect a 200 response:
 
 ```
   -d, --body string          Send a data body string with the request
+  -k, --insecure             Enable insecure SSL connections
   -X, --method string        Specify a GET, POST, or PUT operation; defaults to GET (default "GET")
   -b, --response-bytes int   Print BYTES of the output (default 256)
   -O, --response-code int    Check for a specific response code (default 200)


### PR DESCRIPTION
- `-k` or `--insecure` will now disable ssl validation
- made `http.Client` a field on the `Http` struct. By default it will point to the `http.DefaultClient` which mimics the old behaviour but if `-k` is passed in, then we will create a new http client with ssl disabled. I did this because you have to create a new http client in order to disable SSL validation
- ran `gotfmt`